### PR TITLE
Fix docker base image

### DIFF
--- a/{{cookiecutter.repo_name}}/Dockerfile
+++ b/{{cookiecutter.repo_name}}/Dockerfile
@@ -1,4 +1,4 @@
-FROM xblock-sdk
+FROM jbarciauskas/xblock-sdk
 RUN mkdir -p /usr/local/src/{{cookiecutter.repo_name}}
 VOLUME ["/usr/local/src/{{cookiecutter.repo_name}}"]
 RUN echo "pip install -e /usr/local/src/{{cookiecutter.repo_name}}" >> /usr/local/src/xblock-sdk/install_and_run_xblock.sh


### PR DESCRIPTION
This PR addresses #2.

**Author concern:** In #1 reverse change was made (i.e. `jbarciauskas/xblock-sdk` -> `xblock-sdk`). Did you mean to rename the base image as well (but forgot to do that)?