### PR TITLE
Update template to use statici18n

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,7 @@ Enter the short name and primary class name of your new XBlock when prompted.
 
 To see your new XBlock in action, build and run a Docker image containing it::
 
-        $ docker build -t myxblock .
-        $ docker run -d -p 8000:8000 --name myxblock myxblock
+        $ make dev.run
 
 Your XBlock should now be available at http://localhost:8000
 

--- a/{{cookiecutter.repo_name}}/Dockerfile
+++ b/{{cookiecutter.repo_name}}/Dockerfile
@@ -1,7 +1,10 @@
 FROM jbarciauskas/xblock-sdk
 RUN mkdir -p /usr/local/src/{{cookiecutter.repo_name}}
 VOLUME ["/usr/local/src/{{cookiecutter.repo_name}}"]
+RUN apt-get update && apt-get install -y gettext
+RUN echo "pip install -r /usr/local/src/{{cookiecutter.repo_name}}/requirements.txt" >> /usr/local/src/xblock-sdk/install_and_run_xblock.sh
 RUN echo "pip install -e /usr/local/src/{{cookiecutter.repo_name}}" >> /usr/local/src/xblock-sdk/install_and_run_xblock.sh
+RUN echo "cd /usr/local/src/{{cookiecutter.repo_name}} && make compile_translations && cd /usr/local/src/xblock-sdk" >> /usr/local/src/xblock-sdk/install_and_run_xblock.sh
 RUN echo "exec python /usr/local/src/xblock-sdk/manage.py \"\$@\"" >> /usr/local/src/xblock-sdk/install_and_run_xblock.sh
 RUN chmod +x /usr/local/src/xblock-sdk/install_and_run_xblock.sh
 ENTRYPOINT ["/bin/bash", "/usr/local/src/xblock-sdk/install_and_run_xblock.sh"]

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -1,21 +1,55 @@
-.DEFAULT_GOAL := dev.run
+.DEFAULT_GOAL := help
 
 .PHONY: dev.clean dev.build dev.run
 
+REPO_NAME := {{cookiecutter.repo_name}}
+PACKAGE_NAME := {{cookiecutter.package_name}}
+EXTRACT_DIR := $(PACKAGE_NAME)/locale/en/LC_MESSAGES
+EXTRACTED_DJANGO := $(EXTRACT_DIR)/django-partial.po
+EXTRACTED_DJANGOJS := $(EXTRACT_DIR)/djangojs-partial.po
+EXTRACTED_TEXT := $(EXTRACT_DIR)/text.po
+JS_TARGET := public/js/translations
+TRANSLATIONS_DIR := $(PACKAGE_NAME)/translations
+
 help:
-	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  help                       display this help message"
-	@echo "  dev.clean                  clean up docker development container and image"
-	@echo "  dev.build                  rebuild docker image"
-	@echo "  dev.run                    run the XBlock in the XBlock workbench"
-	@echo ""
+	@perl -nle'print $& if m{^[\.a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
 
 dev.clean:
-	-docker rm {{cookiecutter.repo_name}}-dev
-	-docker rmi {{cookiecutter.repo_name}}-dev
+	-docker rm $(REPO_NAME)-dev
+	-docker rmi $(REPO_NAME)-dev
 
 dev.build:
-	docker build -t {{cookiecutter.repo_name}}-dev $(CURDIR)
+	docker build -t $(REPO_NAME)-dev $(CURDIR)
 
-dev.run: dev.clean dev.build
-	docker run -p 8000:8000 -v $(CURDIR):/usr/local/src/{{cookiecutter.repo_name}} --name {{cookiecutter.repo_name}}-dev {{cookiecutter.repo_name}}-dev
+dev.run: dev.clean dev.build ## Clean, build and run test image
+	docker run -p 8000:8000 -v $(CURDIR):/usr/local/src/$(REPO_NAME) --name $(REPO_NAME)-dev $(REPO_NAME)-dev
+
+## Localization targets
+
+extract_translations: symlink_translations ## extract strings to be translated, outputting .po files
+	cd $(PACKAGE_NAME) && i18n_tool extract
+	mv $(EXTRACTED_DJANGO) $(EXTRACTED_TEXT)
+	if [ -f "$(EXTRACTED_DJANGOJS)" ]; then cat $(EXTRACTED_DJANGOJS) >> $(EXTRACTED_TEXT); rm $(EXTRACTED_DJANGOJS); fi
+
+compile_translations: symlink_translations ## compile translation files, outputting .mo files for each supported language
+	cd $(PACKAGE_NAME) && i18n_tool generate
+	python manage.py compilejsi18n --namespace $(PACKAGE_NAME)i18n --output $(JS_TARGET)
+
+detect_changed_source_translations:
+	cd $(PACKAGE_NAME) && i18n_tool changed
+
+dummy_translations: ## generate dummy translation (.po) files
+	cd $(PACKAGE_NAME) && i18n_tool dummy
+
+build_dummy_translations: dummy_translations compile_translations ## generate and compile dummy translation files
+
+validate_translations: build_dummy_translations detect_changed_source_translations ## validate translations
+
+pull_translations: ## pull translations from transifex
+	cd $(PACKAGE_NAME) && i18n_tool transifex pull
+
+push_translations: extract_translations ## push translations to transifex
+	cd $(PACKAGE_NAME) && i18n_tool transifex push
+
+symlink_translations:
+	if [ ! -d "$(TRANSLATIONS_DIR)" ]; then ln -s locale/ $(TRANSLATIONS_DIR); fi

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -3,12 +3,21 @@ README for {{cookiecutter.project_desc}}
 Testing with Docker
 -------------------
 
-This XBlock comes with a Docker test environment ready to build, based on the xblock-sdk workbench. To build it, run::
+This XBlock comes with a Docker test environment ready to build, based on the xblock-sdk workbench. To build and run it::
 
-        $ docker build -t {{cookiecutter.package_name}} .
-
-Then, to run the docker image you built::
-
-        $ docker run -d -p 8000:8000 --name {{cookiecutter.package_name}} {{cookiecutter.package_name}}
+        $ make dev.run
 
 The XBlock SDK Workbench, including this XBlock, will be available on the list of XBlocks at http://localhost:8000
+
+Translating
+-----------
+
+Use the locale directory to provide internationalized strings for your XBlock project.
+
+For more information on how to enable translations, visit the Open edX XBlock tutorial on Internationalization:
+http://edx.readthedocs.org/projects/xblock-tutorial/en/latest/edx_platform/edx_lms.html
+
+The template uses django-statici18n to provide translations to static javascript
+using `gettext`.
+
+The included Makefile contains targets for extracting, compiling, validating etc.

--- a/{{cookiecutter.repo_name}}/manage.py
+++ b/{{cookiecutter.repo_name}}/manage.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+import os
+import sys
+from django.core.management import execute_from_command_line
+
+if __name__ == "__main__":
+    os.environ.setdefault(
+        "DJANGO_SETTINGS_MODULE",
+        "{{cookiecutter.package_name}}.locale.settings"
+    )
+
+    execute_from_command_line(sys.argv)

--- a/{{cookiecutter.repo_name}}/requirements.txt
+++ b/{{cookiecutter.repo_name}}/requirements.txt
@@ -1,0 +1,6 @@
+git+https://github.com/edx/xblock-utils.git@v1.1.1#egg=xblock-utils==1.1.1
+git+https://github.com/edx/i18n-tools.git
+django-statici18n==1.8.0
+edx-i18n-tools==0.4.7
+Mako==1.0.7
+transifex-client==0.13.4

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/.tx/config
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/.tx/config
@@ -1,0 +1,3 @@
+[main]
+host = https://www.transifex.com
+

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/locale/config.yaml
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/locale/config.yaml
@@ -1,0 +1,93 @@
+# Configuration for i18n workflow.
+
+locales:
+    - en  # English - Source Language
+    # - am  # Amharic
+    - ar  # Arabic
+    # - az  # Azerbaijani
+    # - bg_BG  # Bulgarian (Bulgaria)
+    # - bn_BD  # Bengali (Bangladesh)
+    # - bn_IN  # Bengali (India)
+    # - bs  # Bosnian
+    # - ca  # Catalan
+    # - ca@valencia  # Catalan (Valencia)
+    # - cs  # Czech
+    # - cy  # Welsh
+    # - da  # Danish
+    # - de_DE  # German (Germany)
+    # - el  # Greek
+    # - en_GB  # English (United Kingdom)
+    # # Don't pull these until we figure out why pages randomly display in these locales,
+    # # when the user's browser is in English and the user is not logged in.
+    # #- en@lolcat  # LOLCAT English
+    # #- en@pirate  # Pirate English
+    - es_419  # Spanish (Latin America)
+    # - es_AR  # Spanish (Argentina)
+    # - es_EC  # Spanish (Ecuador)
+    # - es_ES  # Spanish (Spain)
+    # - es_MX  # Spanish (Mexico)
+    # - es_PE  # Spanish (Peru)
+    # - et_EE  # Estonian (Estonia)
+    # - eu_ES  # Basque (Spain)
+    # - fa  # Persian
+    # - fa_IR  # Persian (Iran)
+    # - fi_FI  # Finnish (Finland)
+    # - fil  # Filipino
+    - fr  # French
+    # - gl  # Galician
+    # - gu  # Gujarati
+    - he  # Hebrew
+    - hi  # Hindi
+    # - hr  # Croatian
+    # - hu  # Hungarian
+    # - hy_AM  # Armenian (Armenia)
+    # - id  # Indonesian
+    # - it_IT  # Italian (Italy)
+    # - ja_JP  # Japanese (Japan)
+    # - kk_KZ  # Kazakh (Kazakhstan)
+    # - km_KH  # Khmer (Cambodia)
+    # - kn  # Kannada
+    - ko_KR  # Korean (Korea)
+    # - lt_LT  # Lithuanian (Lithuania)
+    # - ml  # Malayalam
+    # - mn  # Mongolian
+    # - mr  # Marathi
+    # - ms  # Malay
+    # - nb  # Norwegian Bokmål
+    # - ne  # Nepali
+    # - nl_NL  # Dutch (Netherlands)
+    # - or  # Oriya
+    # - pl  # Polish
+    - pt_BR  # Portuguese (Brazil)
+    # - pt_PT  # Portuguese (Portugal)
+    # - ro  # Romanian
+    - ru  # Russian
+    # - si  # Sinhala
+    # - sk  # Slovak
+    # - sl  # Slovenian
+    # - sq  # Albanian
+    # - sr  # Serbian
+    # - sv  # Swedish
+    # - sw  # Swahili
+    # - ta  # Tamil
+    # - te  # Telugu
+    # - th  # Thai
+    # - tr_TR  # Turkish (Turkey)
+    # - uk  # Ukranian
+    # - ur  # Urdu
+    # - uz  # Uzbek
+    # - vi  # Vietnamese
+    - zh_CN  # Chinese (China)
+    # - zh_HK  # Chinese (Hong Kong)
+    # - zh_TW  # Chinese (Taiwan)
+
+
+# The locales used for fake-accented English, for testing.
+dummy_locales:
+    - eo
+    - rtl  # Fake testing language for Arabic
+
+# Directories we don't search for strings.
+ignore_dirs:
+    - '*/css'
+    - 'public/js/translations'

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/locale/settings.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/locale/settings.py
@@ -1,0 +1,46 @@
+"""
+Django settings for {{cookiecutter.package_name}} project.
+For more information on this file, see
+https://docs.djangoproject.com/en/1.11/topics/settings/
+For the full list of settings and their values, see
+https://docs.djangoproject.com/en/1.11/ref/settings/
+"""
+import os
+
+SECRET_KEY = os.getenv('DJANGO_SECRET', 'open_secret')
+
+# Application definition
+
+INSTALLED_APPS = (
+    'statici18n',
+    '{{cookiecutter.package_name}}',
+)
+
+# Internationalization
+# https://docs.djangoproject.com/en/1.11/topics/i18n/
+
+LANGUAGE_CODE = 'en-us'
+
+TIME_ZONE = 'UTC'
+
+USE_I18N = True
+
+USE_L10N = True
+
+USE_TZ = True
+
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/1.11/howto/static-files/
+
+STATIC_URL = '/static/'
+
+# statici18n
+# http://django-statici18n.readthedocs.io/en/latest/settings.html
+
+STATICI18N_DOMAIN = 'text'
+STATICI18N_PACKAGES = (
+    '{{cookiecutter.package_name}}.translations',
+)
+STATICI18N_ROOT = '{{cookiecutter.package_name}}/public/js'
+STATICI18N_OUTPUT_DIR = 'translations'

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/static/js/src/{{cookiecutter.package_name}}.js
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/static/js/src/{{cookiecutter.package_name}}.js
@@ -17,6 +17,12 @@ function {{cookiecutter.class_name}}(runtime, element) {
     });
 
     $(function ($) {
+        /*
+        Use `gettext` provided by django-statici18n for static translations
+
+        var gettext = {{cookiecutter.class_name}}i18n.gettext;
+        */
+
         /* Here's where you'd do things on page load. */
     });
 }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/translations/README.txt
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/translations/README.txt
@@ -1,4 +1,0 @@
-Use this translations directory to provide internationalized strings for your XBlock project.
-
-For more information on how to enable translations, visit the Open edX XBlock tutorial on Internationalization:
-http://edx.readthedocs.org/projects/xblock-tutorial/en/latest/edx_platform/edx_lms.html

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}.py
@@ -2,9 +2,11 @@
 
 import pkg_resources
 
+from django.utils import translation
 from xblock.core import XBlock
 from xblock.fields import Scope, Integer
 from xblock.fragment import Fragment
+from xblockutils.resources import ResourceLoader
 
 
 class {{cookiecutter.class_name}}(XBlock):
@@ -35,6 +37,12 @@ class {{cookiecutter.class_name}}(XBlock):
         html = self.resource_string("static/html/{{cookiecutter.package_name}}.html")
         frag = Fragment(html.format(self=self))
         frag.add_css(self.resource_string("static/css/{{cookiecutter.package_name}}.css"))
+
+        # Add i18n js
+        statici18n_js_url = self._get_statici18n_js_url()
+        if statici18n_js_url:
+            frag.add_javascript_url(self.runtime.local_resource_url(self, statici18n_js_url))
+
         frag.add_javascript(self.resource_string("static/js/src/{{cookiecutter.package_name}}.js"))
         frag.initialize_js('{{cookiecutter.class_name}}')
         return frag
@@ -69,3 +77,28 @@ class {{cookiecutter.class_name}}(XBlock):
                 </vertical_demo>
              """),
         ]
+
+    @staticmethod
+    def _get_statici18n_js_url():
+        """
+        Returns the Javascript translation file for the currently selected language, if any.
+        Defaults to English if available.
+        """
+        locale_code = translation.get_language()
+        if locale_code is None:
+            return None
+        text_js = 'public/js/translations/{locale_code}/text.js'
+        lang_code = locale_code.split('-')[0]
+        for code in (locale_code, lang_code, 'en'):
+            loader = ResourceLoader(__name__)
+            if pkg_resources.resource_exists(
+                    loader.module_name, text_js.format(locale_code=code)):
+                return text_js.format(locale_code=code)
+        return None
+
+    @staticmethod
+    def get_dummy():
+        """
+        Dummy method to generate initial i18n
+        """
+        return translation.gettext_noop('Dummy')


### PR DESCRIPTION
This PR contains modifications to the template to make use of `django-statici18n` to provide translations of static resources. It generates a static javascript that provides `gettext` to be used in static resources without the need to ping the server for translations.

The XBlock is loaded as an INSTALLED_APP in Django to make it possible for `django_statici18n` to generate the translation javascript.

**Merge deadline**: None

**Testing instructions**:

1. Generate an XBlock using this template.
2. Load the generated XBlock in xblock-sdk using `make`
3. Navigate to the XBlock and make sure `test.js` for the selected language loads correctly.

**Author notes and concerns**:

1. This is using a forked repo of `django-statici18n` while its author reviews the pull request needed to make this work. Will update to a release when accepted.

**Reviewers**
- [x] @rocioar
- [ ] edX reviewer[s] TBD