### PR TITLE
Archiving repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+This repository has been archived and is no longer supported—use it at your own risk. This repository may depend on out-of-date libraries with security issues, and security updates will not be provided. Pull requests against this repository will also not be merged.
+
+This cookiecutter has been moved to `edx-cookiecutter`_
+
+.. _edx-cookecutter: https://github.com/edx/edx-cookiecutters
+
 This is a cookiecutter template for new XBlocks.
 
 It enables creation of the XBlock repository as well as a Dockerfile for building and running your XBlock in the xblock-sdk workbench.

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 This repository has been archived and is no longer supported—use it at your own risk. This repository may depend on out-of-date libraries with security issues, and security updates will not be provided. Pull requests against this repository will also not be merged.
 
-This cookiecutter has been moved to `edx-cookiecutter`_
+This cookiecutter has been moved to `edx-cookiecutters`_
 
-.. _edx-cookecutter: https://github.com/edx/edx-cookiecutters
+.. _edx-cookecutters: https://github.com/edx/edx-cookiecutters
 
 This is a cookiecutter template for new XBlocks.
 

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -7,3 +7,4 @@ oeps:
 owner: cpennington
 tags:
     - backend-tooling
+archived: True

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -7,4 +7,4 @@ oeps:
 owner: cpennington
 tags:
     - backend-tooling
-archived: True
+archived: true


### PR DESCRIPTION
This repo has been moved to: https://github.com/edx/edx-cookiecutters
This repo needs to be archived so there are not two places to keep track of.

This is still about a 2-3 days away from archiving. Waiting on some feedback for now.